### PR TITLE
[update]menta

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -23,6 +23,7 @@ module Amulab
 
     config.autoload_paths += %W(#{config.root}/app/models)
 
+    config.time_zone = 'Tokyo'
 
     # config.action_view.image_loading = 'lazy'遅延読み込み
   end


### PR DESCRIPTION
## やったこと
- RailsのデフォルトタイムゾーンはUTC(協定時)となっているため、created_atメソッドやupdated_atメソッドを使って時間を表示させてみると日本時間から９時間差の表記になってしまいます。この差分を埋めるため、タイムゾーンを日本時間に設定しましょう。
　例：config/application.rbファイルにconfig.time_zone = 'Tokyo'を記載。